### PR TITLE
Fixes the semver issue for bower.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "paperfold",
-  "version": "1.0",
+  "version": "1.0.1",
   "homepage": "http://felixniklas.com/paperfold",
   "authors": [
     { "name" : "Felix Niklas",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paperfold",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "3d Paperfold Animation Library",
   "keywords": [
     "paperfold",


### PR DESCRIPTION
bower.json needs to have a valid semver number. `1.0` needed to be `1.0.0`

A new tag needed to be created so that it would reference the right changes, so I just made it `1.0.1` as a maintenance release.
